### PR TITLE
Update dockerfile and readme to include info for connecting to DB on localhost but outside of Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,46 @@ You can cleanup everything, **except the data**, by stopping and removing the co
 
 Starting the containers again with `docker-compose up -d` will still use `./data` directory and restore everything.
 
+## Changes for using a DB on your Localhost outside of Docker
+
+Edit `docker-compose.yaml`:
+ - Change the following:
+Uncomment this
+```
+    extra_hosts:
+    - "host.docker.internal:host-gateway"
+```
+
+Comment out/delete this in both rdm and pma
+```
+    depends_on:
+      - db
+```
+
+
+Your `db_host` needs to be `host.docker.internal` not `localhost`
+
+The DB user you are using needs to have host permissions for either `%` or your docker bridge IP
+
+You can find your docker bridge IP by using
+
+```
+docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' container_name_or_id
+```
+
+if you don't know your container name or id you can view all current containers with `docker ps`
+
+To create a user with % permissions run the following query on your DB
+
+```
+CREATE USER 'USER'@'%' IDENTIFIED BY 'PASSWORD';
+GRANT ALL PRIVILEGES ON DB.* TO 'USER'@'%';
+FLUSH PRIVILEGES;
+```
+
+Your MySQL/MariaDB conf file needs to have either `bind-address = [DOCKERIP]` if you are only connecting from Docker to the DB and nothing else(including localhost!) or  `bind-address = 0.0.0.0` to enable access from any IP (This could open you up to access from any IP on the web so make sure your firewall is correctly configured)
+
+
 ## Minimum Changes For Remote Access
 - Edit `docker-compose.yaml`:
   - Change the following variables accordingly:

--- a/README.md
+++ b/README.md
@@ -124,6 +124,28 @@ Comment out/delete this in both rdm and pma
       - db
 ```
 
+Also make sure to comment out or delete all of the below otherwise you will end up creating a database anyway
+
+```
+ db:
+    image: mariadb:latest
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-authentication-plugin=mysql_native_password --binlog-expire-logs-seconds=86400
+    container_name: atlas-db
+    networks:
+      - atlas-network
+    ports:
+      - 3306:3306
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: pokemodrules
+      MYSQL_DATABASE: rdmdb
+      MYSQL_USER: rdmuser
+      MYSQL_PASSWORD: pokemodrules
+    volumes:
+      - ./data:/var/lib/mysql
+#     - /etc/localtime:/etc/localtime:ro
+```
+
 
 Your `db_host` needs to be `host.docker.internal` not `localhost` anywhere else you need to enter your DB host in docker always use `host.docker.internal`
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Comment out/delete this in both rdm and pma
 ```
 
 
-Your `db_host` needs to be `host.docker.internal` not `localhost`
+Your `db_host` needs to be `host.docker.internal` not `localhost` anywhere else you need to enter your DB host in docker always use `host.docker.internal`
 
 The DB user you are using needs to have host permissions for either `%` or your docker bridge IP
 
@@ -135,7 +135,7 @@ You can find your docker bridge IP by using
 docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' container_name_or_id
 ```
 
-if you don't know your container name or id you can view all current containers with `docker ps`
+If you don't know your container name or id you can view all current containers with `docker ps`
 
 To create a user with % permissions run the following query on your DB
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,11 @@ services:
       LOG_LEVEL: debug
       NO_BACKUP: 1
       NO_REQUIRE_ACCOUNT: 1
+      
+#Uncomment the 2 lines below if using as DB on your localhost outside of docker, then comment out or delete all of db and and depends_on:  -db lines
+#    extra_hosts:
+#    - "host.docker.internal:host-gateway"
+
 ### Uncommenting the following lines will set these values to TRUE (regardless of their value)
 #     USE_RW_FOR_QUEST: 1
 #     USE_RW_FOR_RAID: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     ports:
       - 9000:9000
       - 9001:9001
+      
     environment:
       DB_DATABASE: rdmdb
       DB_HOST: db
@@ -37,10 +38,6 @@ services:
       LOG_LEVEL: debug
       NO_BACKUP: 1
       NO_REQUIRE_ACCOUNT: 1
-      
-#Uncomment the 2 lines below if using as DB on your localhost outside of docker, then comment out or delete all of db and and depends_on:  -db lines
-#    extra_hosts:
-#    - "host.docker.internal:host-gateway"
 
 ### Uncommenting the following lines will set these values to TRUE (regardless of their value)
 #     USE_RW_FOR_QUEST: 1
@@ -58,6 +55,11 @@ services:
 #   security_opt:
 #     - seccomp=unconfined
 #     - apparmor=unconfined
+
+#Uncomment the 2 lines below if using as DB on your localhost outside of docker, then comment out or delete all of db and and depends_on:  -db lines
+#    extra_hosts:
+#    - "host.docker.internal:host-gateway"
+
   db:
     image: mariadb:latest
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-authentication-plugin=mysql_native_password --binlog-expire-logs-seconds=86400


### PR DESCRIPTION
Updated dockerfile to include 

```
#    extra_hosts:
#    - "host.docker.internal:host-gateway"
```

commented out by default

Updated readme to show all information on what to do including getting docker IP if needed and query for creating user with the correct privileges 